### PR TITLE
HTTP Message Proposal (take two)

### DIFF
--- a/proposed/http.md
+++ b/proposed/http.md
@@ -269,17 +269,6 @@ interface ResponseInterface extends MessageInterface
     public function getStatusCode();
 
     /**
-     * Sets the response status code.
-     *
-     * @param integer $statusCode Status code.
-     *
-     * @return self Reference to the response.
-     *
-     * @throws InvalidArgumentException When the status code is not valid.
-     */
-    public function setStatusCode($statusCode);
-
-    /**
      * Gets the response reason phrase.
      *
      * If it has not been explicitly set using `setReasonPhrase()` it SHOULD
@@ -288,14 +277,5 @@ interface ResponseInterface extends MessageInterface
      * @return string|null Reason phrase, or null if unknown.
      */
     public function getReasonPhrase();
-
-    /**
-     * Sets the response reason phrase.
-     *
-     * @param string $reasonPhrase Reason phrase.
-     *
-     * @return self Reference to the response.
-     */
-    public function setReasonPhrase($reasonPhrase);
 }
 ```

--- a/proposed/http.md
+++ b/proposed/http.md
@@ -172,8 +172,6 @@ interface MessageInterface
     /**
      * Gets the body as a string.
      *
-     * If the body is a stream, it will be read at this point.
-     *
      * @return string|null Body as a string, or null if not set.
      */
     public function getBodyAsString();
@@ -181,26 +179,13 @@ interface MessageInterface
     /**
      * Sets the body.
      *
-     * The body SHOULD be one of:
-     *
-     * - string
-     * - object that implements `Serializable`
-     * - `SimpleXMLElement`
-     * - stream
-     * - null
-     * - callable that returns one of the above
-     *
-     * An implementation MUST reject any other form that it does not know how
-     * to turn into a string.
-     *
-     * A callable MUST be called at this point to verify the return type.
-     *
-     * Anything other than a stream MAY immediately be turned into a string;
-     * both forms MUST be stored.
-     *
-     * An implementation MUST NOT read a stream at this point.
+     * The body SHOULD be a string, or an object that implements the
+     * `__toString()` method.
      *
      * A null value will remove the existing body.
+     *
+     * An implementation MAY accept other types, but MUST reject anything that
+     * it does not know how to turn into a string.
      *
      * @param mixed $body Body.
      *

--- a/proposed/http.md
+++ b/proposed/http.md
@@ -232,22 +232,6 @@ interface RequestInterface extends MessageInterface
     public function __toString();
 
     /**
-     * Gets the response object that is associated with this request.
-     *
-     * @return ResponseInterface|null Response, or null if not set.
-     */
-    public function getResponse();
-
-    /**
-     * Sets the response object that is associated with this request.
-     *
-     * @param ResponseInterface $response Response.
-     *
-     * @return RequestInterface Reference to the request.
-     */
-    public function setResponse(ResponseInterface $response);
-
-    /**
      * Gets the method.
      *
      * @return string Method.
@@ -338,22 +322,6 @@ interface ResponseInterface extends MessageInterface
      * @return string Response as an HTTP string.
      */
     public function __toString();
-
-    /**
-     * Gets the request object that is associated with this response.
-     *
-     * @return RequestInterface|null Request, or null if not set.
-     */
-    public function getRequest();
-
-    /**
-     * Sets the request object that is associated with this response.
-     *
-     * @param RequestInterface $request Request.
-     *
-     * @return ResponseInterface Reference to the response.
-     */
-    public function setRequest(RequestInterface $request);
 
     /**
      * {@inheritdoc}

--- a/proposed/http.md
+++ b/proposed/http.md
@@ -398,7 +398,7 @@ interface MessageFactoryInterface
      * @return ResponseInterface
      */
     public function createResponse(
-        $statusCode = null,
+        $statusCode,
         array $headers = array(),
         $body = null,
         array $options = array()

--- a/proposed/http.md
+++ b/proposed/http.md
@@ -279,7 +279,7 @@ interface ResponseInterface extends MessageInterface
     /**
      * Gets the response status code.
      *
-     * @return string Status code.
+     * @return integer Status code.
      */
     public function getStatusCode();
 

--- a/proposed/http.md
+++ b/proposed/http.md
@@ -139,26 +139,6 @@ interface MessageInterface
     public function setHeaders(array $headers);
 
     /**
-     * Adds headers, replacing those that are already set.
-     *
-     * The array keys must the header name, the values the header value.
-     *
-     * The header names and values MUST strings, or objects that implement the
-     * `__toString()` method. The values MAY also be arrays, in which case they
-     * MUST be converted to comma-separated strings; the ordering MUST be
-     * maintained.
-     *
-     * Null values will remove existing headers.
-     *
-     * @param array $headers Headers to add.
-     *
-     * @return self Reference to the message.
-     *
-     * @throws InvalidArgumentException When part of the header set is not valid.
-     */
-    public function addHeaders(array $headers);
-
-    /**
      * Gets the body.
      *
      * This returns the original form, in contrast to `getBodyAsString()`.

--- a/proposed/http.md
+++ b/proposed/http.md
@@ -68,7 +68,7 @@ interface MessageInterface
      *
      * @param string $protocolVersion The HTTP protocol version.
      *
-     * @return MessageInterface A reference to the message.
+     * @return self Reference to the message.
      *
      * @throws InvalidArgumentException When the HTTP protocol version is not valid.
      */
@@ -114,7 +114,7 @@ interface MessageInterface
      * @param string $header Header name.
      * @param string $value  Header value.
      *
-     * @return MessageInterface Reference to the message.
+     * @return self Reference to the message.
      *
      * @throws InvalidArgumentException When the header name or value is not valid.
      */
@@ -132,7 +132,7 @@ interface MessageInterface
      *
      * @param array $headers Headers to set.
      *
-     * @return MessageInterface Reference to the message.
+     * @return self Reference to the message.
      *
      * @throws InvalidArgumentException When part of the header set is not valid.
      */
@@ -152,7 +152,7 @@ interface MessageInterface
      *
      * @param array $headers Headers to add.
      *
-     * @return MessageInterface Reference to the message.
+     * @return self Reference to the message.
      *
      * @throws InvalidArgumentException When part of the header set is not valid.
      */
@@ -202,7 +202,7 @@ interface MessageInterface
      *
      * @param mixed $body Body.
      *
-     * @return MessageInterface Reference to the message.
+     * @return self Reference to the message.
      *
      * @throws InvalidArgumentException When the body is not valid.
      */
@@ -225,13 +225,6 @@ use Psr\Http\Exception\InvalidArgumentException;
 interface RequestInterface extends MessageInterface
 {
     /**
-     * Returns the request as an HTTP string.
-     *
-     * @return string Request as an HTTP string.
-     */
-    public function __toString();
-
-    /**
      * Gets the method.
      *
      * @return string Method.
@@ -243,7 +236,7 @@ interface RequestInterface extends MessageInterface
      *
      * @param string $method Method.
      *
-     * @return RequestInterface Reference to the request.
+     * @return self Reference to the request.
      */
     public function setMethod($method);
 
@@ -259,46 +252,11 @@ interface RequestInterface extends MessageInterface
      *
      * @param string $url URL.
      *
-     * @return RequestInterface Reference to the request.
+     * @return self Reference to the request.
      *
      * @throws InvalidArgumentException If the URL is invalid.
      */
     public function setUrl($url);
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return RequestInterface Reference to the request.
-     */
-    public function setProtocolVersion($protocolVersion);
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return RequestInterface Reference to the request.
-     */
-    public function setHeader($header, $value);
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return RequestInterface Reference to the request.
-     */
-    public function setHeaders(array $headers);
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return RequestInterface Reference to the request.
-     */
-    public function addHeaders(array $headers);
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return RequestInterface Reference to the request.
-     */
-    public function setBody($body);
 }
 ```
 
@@ -317,20 +275,6 @@ use Psr\Http\Exception\InvalidArgumentException;
 interface ResponseInterface extends MessageInterface
 {
     /**
-     * Returns the response as an HTTP string.
-     *
-     * @return string Response as an HTTP string.
-     */
-    public function __toString();
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return ResponseInterface Reference to the response.
-     */
-    public function setProtocolVersion($protocolVersion);
-
-    /**
      * Gets the response status code.
      *
      * @return string Status code.
@@ -342,7 +286,7 @@ interface ResponseInterface extends MessageInterface
      *
      * @param integer $statusCode Status code.
      *
-     * @return ResponseInterface Reference to the response.
+     * @return self Reference to the response.
      *
      * @throws InvalidArgumentException When the status code is not valid.
      */
@@ -363,36 +307,8 @@ interface ResponseInterface extends MessageInterface
      *
      * @param string $reasonPhrase Reason phrase.
      *
-     * @return ResponseInterface Reference to the response.
+     * @return self Reference to the response.
      */
     public function setReasonPhrase($reasonPhrase);
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return ResponseInterface Reference to the response.
-     */
-    public function setHeader($header, $value);
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return ResponseInterface Reference to the response.
-     */
-    public function setHeaders(array $headers);
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return ResponseInterface Reference to the response.
-     */
-    public function addHeaders(array $headers);
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return ResponseInterface Reference to the response.
-     */
-    public function setBody($body);
 }
 ```

--- a/proposed/http.md
+++ b/proposed/http.md
@@ -24,8 +24,8 @@ implemented directly.
 2. Package
 ----------
 
-The interfaces and classes described as well as relevant exception classes and
-a test suite to verify your implementation are provided as part of the
+The interfaces and classes described as well as a test suite to verify your
+implementation are provided as part of the
 [psr/http](https://packagist.org/packages/psr/http) package.
 
 3. Interfaces
@@ -37,8 +37,6 @@ a test suite to verify your implementation are provided as part of the
 <?php
 
 namespace Psr\Http;
-
-use Psr\Http\Exception\InvalidArgumentException;
 
 /**
  * HTTP messages consist of requests from client to server and responses from
@@ -70,7 +68,7 @@ interface MessageInterface
      *
      * @return self Reference to the message.
      *
-     * @throws InvalidArgumentException When the HTTP protocol version is not valid.
+     * @throws \InvalidArgumentException When the HTTP protocol version is not valid.
      */
     public function setProtocolVersion($protocolVersion);
 
@@ -116,7 +114,7 @@ interface MessageInterface
      *
      * @return self Reference to the message.
      *
-     * @throws InvalidArgumentException When the header name or value is not valid.
+     * @throws \InvalidArgumentException When the header name or value is not valid.
      */
     public function setHeader($header, $value);
 
@@ -134,7 +132,7 @@ interface MessageInterface
      *
      * @return self Reference to the message.
      *
-     * @throws InvalidArgumentException When part of the header set is not valid.
+     * @throws \InvalidArgumentException When part of the header set is not valid.
      */
     public function setHeaders(array $headers);
 
@@ -154,7 +152,7 @@ interface MessageInterface
      *
      * @return self Reference to the message.
      *
-     * @throws InvalidArgumentException When part of the header set is not valid.
+     * @throws \InvalidArgumentException When part of the header set is not valid.
      */
     public function addHeaders(array $headers);
 
@@ -191,7 +189,7 @@ interface MessageInterface
      *
      * @return self Reference to the message.
      *
-     * @throws InvalidArgumentException When the body is not valid.
+     * @throws \InvalidArgumentException When the body is not valid.
      */
     public function setBody($body);
 }
@@ -203,8 +201,6 @@ interface MessageInterface
 <?php
 
 namespace Psr\Http;
-
-use Psr\Http\Exception\InvalidArgumentException;
 
 /**
  * A request message from a client to a server.
@@ -241,7 +237,7 @@ interface RequestInterface extends MessageInterface
      *
      * @return self Reference to the request.
      *
-     * @throws InvalidArgumentException If the URL is invalid.
+     * @throws \InvalidArgumentException If the URL is invalid.
      */
     public function setUrl($url);
 }
@@ -253,8 +249,6 @@ interface RequestInterface extends MessageInterface
 <?php
 
 namespace Psr\Http;
-
-use Psr\Http\Exception\InvalidArgumentException;
 
 /**
  * A request message from a server to a client.
@@ -275,7 +269,7 @@ interface ResponseInterface extends MessageInterface
      *
      * @return self Reference to the response.
      *
-     * @throws InvalidArgumentException When the status code is not valid.
+     * @throws \InvalidArgumentException When the status code is not valid.
      */
     public function setStatusCode($statusCode);
 

--- a/proposed/http.md
+++ b/proposed/http.md
@@ -14,19 +14,18 @@ interpreted as described in [RFC 2119][].
 
 ### 1.1 Basics
 
-HTTP messages consist of requests from client to server and responses from
-server to client. These are represented by `Psr\Http\RequestInterface` and
-`Psr\Http\ResponseInterface` respectively.
+HTTP messages consist of requests from a client to a server and responses from
+a server to a client. These messages are represented by
+`Psr\Http\RequestInterface` and `Psr\Http\ResponseInterface` respectively.
 
-Both message types extend `Psr\Http\MessageInterface`, which MUST not be
+Both message types extend from `Psr\Http\MessageInterface`, which SHOULD not be
 implemented directly.
 
 2. Package
 ----------
 
-The interfaces and classes described as well as a test suite to verify your
-implementation are provided as part of the
-[psr/http](https://packagist.org/packages/psr/http) package.
+The interfaces and classes described are provided as part of the
+[psr/http-message](https://packagist.org/packages/psr/http-message) package.
 
 3. Interfaces
 -------------
@@ -39,18 +38,18 @@ implementation are provided as part of the
 namespace Psr\Http;
 
 /**
- * HTTP messages consist of requests from client to server and responses from
- * server to client.
+ * HTTP messages consist of requests from a client to a server and responses
+ * from a server to a client.
  *
- * This interface is not to be implemented directly, instead implement
+ * This interface SHOULD not be implemented directly; instead, implement
  * `RequestInterface` or `ResponseInterface` as appropriate.
  */
 interface MessageInterface
 {
     /**
-     * Returns the message as an HTTP string.
+     * Returns a string representation of the HTTP message.
      *
-     * @return string Message as an HTTP string.
+     * @return string Message as a string.
      */
     public function __toString();
 
@@ -62,18 +61,11 @@ interface MessageInterface
     public function getProtocolVersion();
 
     /**
-     * Sets the HTTP protocol version.
+     * Retrieve an HTTP header by name.
      *
-     * @param string $protocolVersion The HTTP protocol version.
-     *
-     * @return self Reference to the message.
-     *
-     * @throws \InvalidArgumentException When the HTTP protocol version is not valid.
-     */
-    public function setProtocolVersion($protocolVersion);
-
-    /**
-     * Gets a header.
+     * If a header contains multiple values for the given case-insensitive name,
+     * then the header values MUST be combined using a comma separator followed
+     * by a space (i.e., ", ") as specified in RFC 2616.
      *
      * @param string $header Header name.
      *
@@ -84,90 +76,82 @@ interface MessageInterface
     /**
      * Gets all headers.
      *
-     * The array keys are the header name, the values the header value.
+     * The keys represent the header name as it will be sent over the wire, and
+     * the values are an array of strings representing the header values.
      *
-     * @return array Headers.
+     * The return value of this method MUST be an array or a PHP object that
+     * implements \Traversable.
+     *
+     * @return array|Traversable An iterable representation of all of the
+     *                           message's HTTP headers.
      */
     public function getHeaders();
 
     /**
-     * Checks if a certain header is present.
+     * Checks if a header exists by the given case-insensitive name.
      *
-     * @param string $header Header name.
+     * @param string $header Case-insensitive header name.
      *
-     * @return bool If the header is present.
+     * @return bool Returns true if any header names match the given header
+     *              name using a case-insensitive string comparison. Returns
+     *              false if no matching header name is found in the message.
      */
     public function hasHeader($header);
 
     /**
-     * Sets a header, replacing the existing header if has already been set.
+     * Sets a header, replacing any existing values of any headers with the
+     * same case-insensitive name.
      *
      * The header name and value MUST be a string, or an object that implement
-     * the `__toString()` method. The value MAY also be an array, in which case
-     * it MUST be converted to a comma-separated string; the ordering MUST be
-     * maintained.
+     * the `__toString()` method. The value MAY also be an array of header
+     * values.
      *
-     * A null value will remove the existing header.
+     * @param string       $header Header name
+     * @param string|array $value  Header value(s)
      *
-     * @param string $header Header name.
-     * @param string $value  Header value.
-     *
-     * @return self Reference to the message.
+     * @return self Returns the message.
      *
      * @throws \InvalidArgumentException When the header name or value is not valid.
      */
     public function setHeader($header, $value);
 
     /**
-     * Sets headers, removing any that have already been set.
+     * Sets headers, replacing any headers that have already been set on the
+     * message.
      *
-     * The array keys must the header name, the values the header value.
-     *
-     * The header names and values MUST strings, or objects that implement the
-     * `__toString()` method. The values MAY also be arrays, in which case they
-     * MUST be converted to comma-separated strings; the ordering MUST be
-     * maintained.
+     * The array keys must be strings representing the header name. The values
+     * for each key MUST be one of the following: string, and object that
+     * implements the `__toString()` method, or an array of string values.
      *
      * @param array $headers Headers to set.
      *
-     * @return self Reference to the message.
+     * @return self Returns the message.
      *
      * @throws \InvalidArgumentException When part of the header set is not valid.
      */
     public function setHeaders(array $headers);
 
     /**
-     * Gets the body.
+     * Gets the body of the message.
      *
-     * This returns the original form, in contrast to `getBodyAsString()`.
-     *
-     * @return mixed|null Body, or null if not set.
-     *
-     * @see getBodyAsString()
+     * @return mixed|null Returns the message body, or null if not set.
      */
     public function getBody();
 
     /**
-     * Gets the body as a string.
-     *
-     * @return string|null Body as a string, or null if not set.
-     */
-    public function getBodyAsString();
-
-    /**
-     * Sets the body.
+     * Sets the body of the message.
      *
      * The body SHOULD be a string, or an object that implements the
      * `__toString()` method.
      *
-     * A null value will remove the existing body.
+     * A null value MUST remove the existing body.
      *
      * An implementation MAY accept other types, but MUST reject anything that
      * it does not know how to turn into a string.
      *
      * @param mixed $body Body.
      *
-     * @return self Reference to the message.
+     * @return self Returns the message.
      *
      * @throws \InvalidArgumentException When the body is not valid.
      */
@@ -183,37 +167,42 @@ interface MessageInterface
 namespace Psr\Http;
 
 /**
- * A request message from a client to a server.
+ * A HTTP request message.
+ * @link http://tools.ietf.org/html/rfc2616#section-5
  */
 interface RequestInterface extends MessageInterface
 {
     /**
-     * Gets the method.
+     * Gets the method of the request.
      *
-     * @return string Method.
+     * @return string Returns the request method.
      */
     public function getMethod();
 
     /**
-     * Sets the method.
+     * Sets the method to be performed on the resource identified by the
+     * Request-URI. The method is case-sensitive.
      *
-     * @param string $method Method.
+     * @param string $method Case-insensitive method.
      *
-     * @return self Reference to the request.
+     * @return self Returns the request.
      */
     public function setMethod($method);
 
     /**
-     * Gets the absolute URL.
+     * Gets the request URL.
      *
      * @return string URL.
      */
     public function getUrl();
 
     /**
-     * Sets the absolute URL.
+     * Sets the request URL.
      *
-     * @param string $url URL.
+     * The URL MUST be a string, or an object that implements the
+     * `__toString()` method.
+     *
+     * @param string $url Request URL.
      *
      * @return self Reference to the request.
      *
@@ -231,22 +220,27 @@ interface RequestInterface extends MessageInterface
 namespace Psr\Http;
 
 /**
- * A request message from a server to a client.
+ * A HTTP response message.
+ * @link http://tools.ietf.org/html/rfc2616#section-6
  */
 interface ResponseInterface extends MessageInterface
 {
     /**
-     * Gets the response status code.
+     * Gets the response Status-Code, a 3-digit integer result code of the
+     * server's attempt to understand and satisfy the request.
      *
      * @return integer Status code.
      */
     public function getStatusCode();
 
     /**
-     * Gets the response reason phrase.
+     * Gets the response Reason-Phrase, a short textual description of the
+     * Status-Code.
      *
-     * If it has not been explicitly set using `setReasonPhrase()` it SHOULD
-     * return the RFC 2616 recommended reason phrase.
+     * Because a Reason-Phrase is not a required element in response
+     * Status-Line, the Reason-Phrase value MAY be null. Implementations MAY
+     * choose to return the default RFC 2616 recommended reason phrase for the
+     * response's Status-Code.
      *
      * @return string|null Reason phrase, or null if unknown.
      */

--- a/proposed/http.md
+++ b/proposed/http.md
@@ -1,0 +1,430 @@
+﻿HTTP message interfaces
+=======================
+
+This document describes common interfaces for representing HTTP messages.
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119][].
+
+[RFC 2119]: http://tools.ietf.org/html/rfc2119
+
+1. Specification
+----------------
+
+### 1.1 Basics
+
+HTTP messages consist of requests from client to server and responses from
+server to client. These are represented by `Psr\Http\RequestInterface` and
+`Psr\Http\ResponseInterface` respectively.
+
+Both message types extend `Psr\Http\MessageInterface`, which MUST not be
+implemented directly.
+
+2. Package
+----------
+
+The interfaces and classes described as well as relevant exception classes and
+a test suite to verify your implementation are provided as part of the
+[psr/http](https://packagist.org/packages/psr/http) package.
+
+3. Interfaces
+-------------
+
+### 3.1 `Psr\Http\MessageInterface`
+
+```php
+<?php
+
+namespace Psr\Http;
+
+use Psr\Http\Exception\InvalidArgumentException;
+
+/**
+ * HTTP messages consist of requests from client to server and responses from
+ * server to client.
+ *
+ * This interface is not to be implemented directly, instead implement
+ * `RequestInterface` or `ResponseInterface` as appropriate.
+ */
+interface MessageInterface
+{
+    /**
+     * Returns the message as an HTTP string.
+     *
+     * @return string Message as an HTTP string.
+     */
+    public function __toString();
+
+    /**
+     * Gets the HTTP protocol version.
+     *
+     * @return string HTTP protocol version.
+     */
+    public function getProtocolVersion();
+
+    /**
+     * Sets the HTTP protocol version.
+     *
+     * @param string $protocolVersion The HTTP protocol version.
+     *
+     * @return MessageInterface A reference to the message.
+     *
+     * @throws InvalidArgumentException When the HTTP protocol version is not valid.
+     */
+    public function setProtocolVersion($protocolVersion);
+
+    /**
+     * Gets a header.
+     *
+     * @param string $header Header name.
+     *
+     * @return string|null Header value, or null if not set.
+     */
+    public function getHeader($header);
+
+    /**
+     * Gets all headers.
+     *
+     * The array keys are the header name, the values the header value.
+     *
+     * @return array Headers.
+     */
+    public function getHeaders();
+
+    /**
+     * Checks if a certain header is present.
+     *
+     * @param string $header Header name.
+     *
+     * @return bool If the header is present.
+     */
+    public function hasHeader($header);
+
+    /**
+     * Sets a header, replacing the existing header if has already been set.
+     *
+     * The header name and value MUST be a string, or an object that implement
+     * the `__toString()` method. The value MAY also be an array, in which case
+     * it MUST be converted to a comma-separated string; the ordering MUST be
+     * maintained.
+     *
+     * A null value will remove the existing header.
+     *
+     * @param string $header Header name.
+     * @param string $value  Header value.
+     *
+     * @return MessageInterface Reference to the message.
+     *
+     * @throws InvalidArgumentException When the header name or value is not valid.
+     */
+    public function setHeader($header, $value);
+
+    /**
+     * Sets headers, removing any that have already been set.
+     *
+     * The array keys must the header name, the values the header value.
+     *
+     * The header names and values MUST strings, or objects that implement the
+     * `__toString()` method. The values MAY also be arrays, in which case they
+     * MUST be converted to comma-separated strings; the ordering MUST be
+     * maintained.
+     *
+     * @param array $headers Headers to set.
+     *
+     * @return MessageInterface Reference to the message.
+     *
+     * @throws InvalidArgumentException When part of the header set is not valid.
+     */
+    public function setHeaders(array $headers);
+
+    /**
+     * Adds headers, replacing those that are already set.
+     *
+     * The array keys must the header name, the values the header value.
+     *
+     * The header names and values MUST strings, or objects that implement the
+     * `__toString()` method. The values MAY also be arrays, in which case they
+     * MUST be converted to comma-separated strings; the ordering MUST be
+     * maintained.
+     *
+     * Null values will remove existing headers.
+     *
+     * @param array $headers Headers to add.
+     *
+     * @return MessageInterface Reference to the message.
+     *
+     * @throws InvalidArgumentException When part of the header set is not valid.
+     */
+    public function addHeaders(array $headers);
+
+    /**
+     * Gets the body.
+     *
+     * This returns the original form, in contrast to `getBodyAsString()`.
+     *
+     * @return mixed|null Body, or null if not set.
+     *
+     * @see getBodyAsString()
+     */
+    public function getBody();
+
+    /**
+     * Gets the body as a string.
+     *
+     * If the body is a stream, it will be read at this point.
+     *
+     * @return string|null Body as a string, or null if not set.
+     */
+    public function getBodyAsString();
+
+    /**
+     * Sets the body.
+     *
+     * The body SHOULD be one of:
+     *
+     * - string
+     * - callable that returns a string
+     * - object that implements `Serializable`
+     * - `SimpleXMLElement`
+     * - stream
+     * - null
+     *
+     * An implementation MUST reject any other form that it does not know how
+     * to turn into a string.
+     *
+     * Anything other than a stream MAY immediately be turned into a string;
+     * both forms MUST be stored.
+     *
+     * An implementation MUST NOT read a stream at this point.
+     *
+     * A null value will remove the existing body.
+     *
+     * @param mixed $body Body.
+     *
+     * @return MessageInterface Reference to the message.
+     *
+     * @throws InvalidArgumentException When the body is not valid.
+     */
+    public function setBody($body);
+}
+```
+
+### 3.2 `Psr\Http\RequestInterface`
+
+```php
+<?php
+
+namespace Psr\Http;
+
+use Psr\Http\Exception\InvalidArgumentException;
+
+/**
+ * A request message from a client to a server.
+ */
+interface RequestInterface extends MessageInterface
+{
+    /**
+     * Returns the request as an HTTP string.
+     *
+     * @return string Request as an HTTP string.
+     */
+    public function __toString();
+
+    /**
+     * Gets the response object that is associated with this request.
+     *
+     * @return ResponseInterface|null Response, or null if not set.
+     */
+    public function getResponse();
+
+    /**
+     * Sets the response object that is associated with this request.
+     *
+     * @param ResponseInterface $response Response.
+     *
+     * @return RequestInterface Reference to the request.
+     */
+    public function setResponse(ResponseInterface $response);
+
+    /**
+     * Gets the method.
+     *
+     * @return string Method.
+     */
+    public function getMethod();
+
+    /**
+     * Sets the method.
+     *
+     * @param string $method Method.
+     *
+     * @return RequestInterface Reference to the request.
+     */
+    public function setMethod($method);
+
+    /**
+     * Gets the absolute URL.
+     *
+     * @return string URL.
+     */
+    public function getUrl();
+
+    /**
+     * Sets the absolute URL.
+     *
+     * @param string $url URL.
+     *
+     * @return RequestInterface Reference to the request.
+     *
+     * @throws InvalidArgumentException If the URL is invalid.
+     */
+    public function setUrl($url);
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return RequestInterface Reference to the request.
+     */
+    public function setProtocolVersion($protocolVersion);
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return RequestInterface Reference to the request.
+     */
+    public function setHeader($header, $value);
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return RequestInterface Reference to the request.
+     */
+    public function setHeaders(array $headers);
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return RequestInterface Reference to the request.
+     */
+    public function addHeaders(array $headers);
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return RequestInterface Reference to the request.
+     */
+    public function setBody($body);
+}
+```
+
+### 3.3 `Psr\Http\ResponseInterface`
+
+```php
+<?php
+
+namespace Psr\Http;
+
+use Psr\Http\Exception\InvalidArgumentException;
+
+/**
+ * A request message from a server to a client.
+ */
+interface ResponseInterface extends MessageInterface
+{
+    /**
+     * Returns the response as an HTTP string.
+     *
+     * @return string Response as an HTTP string.
+     */
+    public function __toString();
+
+    /**
+     * Gets the request object that is associated with this response.
+     *
+     * @return RequestInterface|null Request, or null if not set.
+     */
+    public function getRequest();
+
+    /**
+     * Sets the request object that is associated with this response.
+     *
+     * @param RequestInterface $request Request.
+     *
+     * @return ResponseInterface Reference to the response.
+     */
+    public function setRequest(RequestInterface $request);
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return ResponseInterface Reference to the response.
+     */
+    public function setProtocolVersion($protocolVersion);
+
+    /**
+     * Gets the response status code.
+     *
+     * @return string Status code.
+     */
+    public function getStatusCode();
+
+    /**
+     * Sets the response status code.
+     *
+     * @param integer $statusCode Status code.
+     *
+     * @return ResponseInterface Reference to the response.
+     *
+     * @throws InvalidArgumentException When the status code is not valid.
+     */
+    public function setStatusCode($statusCode);
+
+    /**
+     * Gets the response reason phrase.
+     *
+     * If it has not been explicitly set using `setReasonPhrase()` it SHOULD
+     * return the RFC 2616 recommended reason phrase.
+     *
+     * @return string|null Reason phrase, or null if unknown.
+     */
+    public function getReasonPhrase();
+
+    /**
+     * Sets the response reason phrase.
+     *
+     * @param string $reasonPhrase Reason phrase.
+     *
+     * @return ResponseInterface Reference to the response.
+     */
+    public function setReasonPhrase($reasonPhrase);
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return ResponseInterface Reference to the response.
+     */
+    public function setHeader($header, $value);
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return ResponseInterface Reference to the response.
+     */
+    public function setHeaders(array $headers);
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return ResponseInterface Reference to the response.
+     */
+    public function addHeaders(array $headers);
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return ResponseInterface Reference to the response.
+     */
+    public function setBody($body);
+}
+```

--- a/proposed/http.md
+++ b/proposed/http.md
@@ -184,14 +184,16 @@ interface MessageInterface
      * The body SHOULD be one of:
      *
      * - string
-     * - callable that returns a string
      * - object that implements `Serializable`
      * - `SimpleXMLElement`
      * - stream
      * - null
+     * - callable that returns one of the above
      *
      * An implementation MUST reject any other form that it does not know how
      * to turn into a string.
+     *
+     * A callable MUST be called at this point to verify the return type.
      *
      * Anything other than a stream MAY immediately be turned into a string;
      * both forms MUST be stored.


### PR DESCRIPTION
This proposed PSR provides interfaces that can be used for representing HTTP messages.

This PR provides the following interfaces:
- `MessageInterface`
- `HasHeadersInterface`
- `HeaderValuesInterface`
- `RequestInterface`
- `ResponseInterface`
- `MessageFactoryInterface`
- `StreamInterface`.

The motivation for each interface and the design decisions that were made can be found in the "Design Decisions" section of the document.

Note: This pull request is a (mostly rewritten) fork of https://github.com/php-fig/fig-standards/pull/72.
